### PR TITLE
cores.i2c: Expose write interface in I2C Init core, add I2CRegStream

### DIFF
--- a/lambdalib/cores/i2c/init.py
+++ b/lambdalib/cores/i2c/init.py
@@ -8,9 +8,13 @@ from ..mem.stream import *
 
 
 class I2CRegisterInit(Elaboratable):
+    """Sends an init sequence to an I2C device. I2C writer
+    can be exposed for further usage (eg. readjusting 
+    parameters after init)."""
     def __init__(self,
                  sys_clk_freq, i2c_addr, regs_data,
-                 i2c_freq=400e3, i2c_pins=None):
+                 i2c_freq=400e3, i2c_pins=None,
+                 expose_writer=False):
 
         self.sys_clk_freq = sys_clk_freq
         self.i2c_addr = i2c_addr
@@ -18,6 +22,11 @@ class I2CRegisterInit(Elaboratable):
         self.i2c_freq = i2c_freq
         self.i2c_pins = i2c_pins
         self.done = Signal()  # Asserted when init sequence has been sent
+
+        if expose_writer:
+            self.writer = stream.Endpoint([("data", 8)])
+        else:
+            self.writer = None
 
     def regs_data_to_mem(self, regs_data):
         mem = []
@@ -38,8 +47,21 @@ class I2CRegisterInit(Elaboratable):
         i2c_period = (self.sys_clk_freq // self.i2c_freq)
         m.submodules.writer = writer = I2CWriterStream(self.i2c_pins, i2c_period)
 
-        m.d.comb += mem.source.connect(writer.sink)
         with m.If(mem.source.valid & mem.source.ready & mem.source.last):
             m.d.sync += self.done.eq(1)
+
+        if self.writer is None:
+            m.d.comb += mem.source.connect(writer.sink)
+        else:
+            with m.If(~self.done):
+                m.d.comb += [
+                    mem.source.connect(writer.sink),
+                    self.writer.ready.eq(0),
+                ]
+            with m.Else():
+                m.d.comb += [
+                    self.writer.connect(writer.sink),
+                    mem.source.ready.eq(0),
+                ]
 
         return m

--- a/lambdalib/cores/i2c/init.py
+++ b/lambdalib/cores/i2c/init.py
@@ -17,6 +17,7 @@ class I2CRegisterInit(Elaboratable):
         self.regs_data = regs_data
         self.i2c_freq = i2c_freq
         self.i2c_pins = i2c_pins
+        self.done = Signal()  # Asserted when init sequence has been sent
 
     def regs_data_to_mem(self, regs_data):
         mem = []
@@ -38,5 +39,7 @@ class I2CRegisterInit(Elaboratable):
         m.submodules.writer = writer = I2CWriterStream(self.i2c_pins, i2c_period)
 
         m.d.comb += mem.source.connect(writer.sink)
+        with m.If(mem.source.valid & mem.source.ready & mem.source.last):
+            m.d.sync += self.done.eq(1)
 
         return m


### PR DESCRIPTION
* Expose write interface in I2C Init core for further register writes after POR initialization.
* Add I2CRegStream for generating I2C commands from a stream of register addresses/values